### PR TITLE
refactor(filter-restore): unify restore flow and dedupe filtered paging

### DIFF
--- a/app/src/main/java/com/geoffreysisco/filmatlas/MainActivity.java
+++ b/app/src/main/java/com/geoffreysisco/filmatlas/MainActivity.java
@@ -155,6 +155,22 @@ public class MainActivity extends AppCompatActivity
     private boolean suppressFilterObserverOnceAfterStateRestore = false;
     private boolean didResumeRestore = false;
 
+    private static final class FilterRestoreSnapshot {
+        final int nav;
+        final boolean filterApplied;
+        final List<Movie> restoredMovies;
+
+        FilterRestoreSnapshot(
+                int nav,
+                boolean filterApplied,
+                List<Movie> restoredMovies
+        ) {
+            this.nav = nav;
+            this.filterApplied = filterApplied;
+            this.restoredMovies = restoredMovies;
+        }
+    }
+
     // =====================
     // Lifecycle
     // =====================
@@ -179,44 +195,16 @@ public class MainActivity extends AppCompatActivity
 
         // Resume restore (process death / external return):
         // Only resume to Filter if we have a list snapshot; otherwise fall back to normal startup (Discover).
+        FilterRestoreSnapshot resumeFilterSnapshot = null;
+        int resumeFirst = 0;
         if (savedInstanceState == null && !isNormalLauncherStart) {
+            resumeFilterSnapshot = buildFilterRestoreSnapshotFromSharedPreferences();
 
             SharedPreferences sp = getSharedPreferences("filmatlas_ui", MODE_PRIVATE);
+            resumeFirst = sp.getInt("resume_first", 0);
 
-            int resumeNav = sp.getInt("resume_nav", -1);
-            int resumeFirst = sp.getInt("resume_first", 0);
-            boolean resumeFilterApplied = sp.getBoolean("resume_filter_applied", false);
-
-            String resumeJson = sp.getString("resume_filter_movies_json", "");
-            boolean hasResumeJson = (resumeJson != null && !resumeJson.trim().isEmpty());
-
-            if (resumeNav == NAV_FILTER && resumeFilterApplied && hasResumeJson) {
-
+            if (resumeFilterSnapshot != null) {
                 didResumeRestore = true;
-
-                // Enter filter UI mode without opening bottom sheet / without clearing list.
-                selectNavIndex(NAV_FILTER, false);
-
-                // Restore VM applied flag so paging logic is consistent.
-                viewModel.restoreMovieFilterApplied(true);
-
-                try {
-                    java.lang.reflect.Type type =
-                            new com.google.gson.reflect.TypeToken<java.util.List<com.geoffreysisco.filmatlas.model.Movie>>() {}.getType();
-
-                    java.util.List<Movie> restored =
-                            new com.google.gson.Gson().fromJson(resumeJson, type);
-
-                    if (restored != null && !restored.isEmpty()) {
-                        movieAdapter.submitList(restored, () ->
-                                binding.recyclerView.post(() ->
-                                        gridLayoutManager.scrollToPosition(Math.max(0, resumeFirst))
-                                )
-                        );
-                    }
-                } catch (Exception ignored) {
-                    // Ignore restore errors — resume state is non-critical
-                }
             }
         }
 
@@ -260,52 +248,28 @@ public class MainActivity extends AppCompatActivity
         setupSystemInsets();
         setupRecycler();
 
+        if (resumeFilterSnapshot != null) {
+            final int restoredFirst = resumeFirst;
+            applyFilterSnapshot(resumeFilterSnapshot, () ->
+                    gridLayoutManager.scrollToPosition(Math.max(0, restoredFirst)));
+        }
+
         if (savedInstanceState != null) {
-            String json = savedInstanceState.getString(KEY_FILTER_MOVIES_JSON);
+            FilterRestoreSnapshot snapshot =
+                    buildFilterRestoreSnapshotFromSavedState(savedInstanceState);
 
-            boolean restoredFilterApplied = savedInstanceState.getBoolean(KEY_FILTER_APPLIED, false);
+            if (snapshot != null) {
+                suppressFilterObserverOnceAfterStateRestore = true;
 
-            if (json != null && !json.trim().isEmpty()) {
-                try {
-                    java.lang.reflect.Type type =
-                            new com.google.gson.reflect.TypeToken<java.util.List<Movie>>() {}.getType();
-                    java.util.List<Movie> restored =
-                            new com.google.gson.Gson().fromJson(json, type);
+                applyFilterSnapshot(snapshot, () -> {
+                    RecyclerView.LayoutManager lm = binding.recyclerView.getLayoutManager();
 
-                    if (restored != null && !restored.isEmpty()) {
-
-                        // If we restored filter results from state, we must also restore the VM “applied” flag,
-                        // otherwise paging will be blocked (canPage=false) after process death restore.
-                        if (selectedNavIndex == NAV_FILTER && restoredFilterApplied) {
-                            viewModel.restoreMovieFilterApplied(true);
-                        }
-
-                        suppressFilterObserverOnceAfterStateRestore = true;
-
-                        movieAdapter.submitList(restored, () -> {
-                            binding.recyclerView.post(() -> {
-
-                                hideFilterEmptyState();
-                                binding.recyclerView.setVisibility(View.VISIBLE);
-
-                                RecyclerView.LayoutManager lm = binding.recyclerView.getLayoutManager();
-                                int lmCount = (lm == null) ? -1 : lm.getItemCount();
-
-                                if (pendingRvState != null && pendingRvNavIndex == selectedNavIndex && lm != null) {
-                                    lm.onRestoreInstanceState(pendingRvState);
-                                    pendingRvState = null;
-                                    pendingRvNavIndex = -1;
-                                }
-
-                                int firstNow = gridLayoutManager.findFirstVisibleItemPosition();
-
-                                updateFilterFabVisibility();
-                            });
-                        });
+                    if (pendingRvState != null && pendingRvNavIndex == selectedNavIndex && lm != null) {
+                        lm.onRestoreInstanceState(pendingRvState);
+                        pendingRvState = null;
+                        pendingRvNavIndex = -1;
                     }
-                } catch (Exception ignored) {
-                    // no-op
-                }
+                });
             }
         }
 
@@ -455,19 +419,6 @@ public class MainActivity extends AppCompatActivity
 
                     if (restoringBrowseUi) {
                         kickBrowseLoadIfNeeded();
-                    }
-                }
-
-                // Rotation restore: ONLY re-apply if we have nothing to display (e.g., process death).
-                if (selectedNavIndex == NAV_FILTER && viewModel.isMovieFilterApplied()) {
-
-                    List<Movie> current = (movieAdapter == null) ? null : movieAdapter.getCurrentList();
-                    boolean hasList = (current != null && !current.isEmpty());
-
-                    if (!hasList) {
-                        MovieFilterOptions opts = viewModel.getActiveMovieFilterOptions().getValue();
-                        if (opts == null) opts = MovieFilterOptions.defaults();
-                        viewModel.applyMovieFilter(opts);
                     }
                 }
 
@@ -2010,6 +1961,106 @@ public class MainActivity extends AppCompatActivity
     }
 
     // --- Filter ---
+
+    private FilterRestoreSnapshot buildFilterRestoreSnapshotFromSharedPreferences() {
+
+        SharedPreferences sp = getSharedPreferences("filmatlas_ui", MODE_PRIVATE);
+
+        int resumeNav = sp.getInt("resume_nav", -1);
+        boolean resumeFilterApplied = sp.getBoolean("resume_filter_applied", false);
+
+        String resumeJson = sp.getString("resume_filter_movies_json", null);
+
+        if (resumeNav != NAV_FILTER) return null;
+        if (!resumeFilterApplied) return null;
+        if (resumeJson == null || resumeJson.trim().isEmpty()) return null;
+
+        try {
+            java.lang.reflect.Type type =
+                    new com.google.gson.reflect.TypeToken<java.util.List<Movie>>() {
+                    }.getType();
+
+            java.util.List<Movie> restored =
+                    new com.google.gson.Gson().fromJson(resumeJson, type);
+
+            if (restored == null || restored.isEmpty()) {
+                return null;
+            }
+
+            return new FilterRestoreSnapshot(
+                    NAV_FILTER,
+                    true,
+                    restored
+            );
+
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
+
+    private FilterRestoreSnapshot buildFilterRestoreSnapshotFromSavedState(@NonNull Bundle savedInstanceState) {
+
+        int restoredNav = savedInstanceState.getInt(
+                KEY_SELECTED_NAV_INDEX,
+                mapBrowseTabToNavIndex(selectedTabIndex)
+        );
+
+        boolean restoredFilterApplied =
+                savedInstanceState.getBoolean(KEY_FILTER_APPLIED, false);
+
+        String json = savedInstanceState.getString(KEY_FILTER_MOVIES_JSON, "");
+        boolean hasJson = (json != null && !json.trim().isEmpty());
+
+        if (restoredNav != NAV_FILTER || !restoredFilterApplied || !hasJson) {
+            return null;
+        }
+
+        try {
+            java.lang.reflect.Type type =
+                    new com.google.gson.reflect.TypeToken<java.util.List<Movie>>() {
+                    }.getType();
+
+            java.util.List<Movie> restored =
+                    new com.google.gson.Gson().fromJson(json, type);
+
+            if (restored == null || restored.isEmpty()) {
+                return null;
+            }
+
+            return new FilterRestoreSnapshot(
+                    NAV_FILTER,
+                    true,
+                    restored
+            );
+
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
+
+    private void applyFilterSnapshot(
+            @NonNull FilterRestoreSnapshot snapshot,
+            @Nullable Runnable afterSubmit
+    ) {
+        selectNavIndex(NAV_FILTER, false);
+        viewModel.restoreMovieFilterApplied(snapshot.filterApplied);
+
+        if (snapshot.restoredMovies == null || snapshot.restoredMovies.isEmpty()) {
+            return;
+        }
+
+        movieAdapter.submitList(snapshot.restoredMovies, () ->
+                binding.recyclerView.post(() -> {
+                    hideFilterEmptyState();
+                    binding.recyclerView.setVisibility(View.VISIBLE);
+                    updateFilterFabVisibility();
+
+                    if (afterSubmit != null) {
+                        afterSubmit.run();
+                    }
+                })
+        );
+    }
 
     private void refreshFilterOrShowEmptyState() {
         if (viewModel.isMovieFilterApplied()) {

--- a/app/src/main/java/com/geoffreysisco/filmatlas/repository/MovieRepository.java
+++ b/app/src/main/java/com/geoffreysisco/filmatlas/repository/MovieRepository.java
@@ -51,6 +51,7 @@ public class MovieRepository {
 
     private final ArrayList<Movie> browseMovies = new ArrayList<>();
     private final MutableLiveData<List<Movie>> browseLiveData = new MutableLiveData<>();
+    private final Set<Integer> filteredSeenMovieIds = new HashSet<>();
 
     private int movieFilteredEmptySkips = 0;
     private int discoverEmptySkips = 0;
@@ -131,6 +132,7 @@ public class MovieRepository {
         browseLiveData.setValue(new ArrayList<>());
         browseCurrentPage = 1;
         browseTotalPages = Integer.MAX_VALUE;
+        filteredSeenMovieIds.clear();
         loadNextPageBrowse(cb);
     }
 
@@ -195,6 +197,23 @@ public class MovieRepository {
                 }
 
                 List<Movie> filtered = filterOutMissingPosters(body.getMovies());
+
+                if (browseMode == BrowseMode.MOVIES_FILTERED) {
+                    List<Movie> deduped = new ArrayList<>();
+
+                    for (Movie m : filtered) {
+                        if (m == null) continue;
+
+                        Integer id = m.getId();
+                        if (id == null) continue;
+
+                        if (filteredSeenMovieIds.add(id)) {
+                            deduped.add(m);
+                        }
+                    }
+
+                    filtered = deduped;
+                }
 
                 if (browseMode == BrowseMode.DISCOVER_RANDOM) {
                     List<Movie> deduped = new ArrayList<>();
@@ -481,5 +500,6 @@ public class MovieRepository {
     public void clearBrowseResults() {
         browseMovies.clear();
         browseLiveData.setValue(new ArrayList<>());
+        filteredSeenMovieIds.clear();
     }
 }


### PR DESCRIPTION
## Summary

This PR refactors the Filter restore flow in `MainActivity` so restore is driven by a single validated snapshot contract instead of a distributed multi-flag handshake across multiple restore entry points.

It also fixes duplicate movie entries appearing during filtered paging by deduplicating filtered results at the repository layer.

## What changed

### 1. Unified Filter restore around a validated snapshot
Introduced a small internal `FilterRestoreSnapshot` in `MainActivity` to represent a valid Filter restore state:

- `nav`
- `filterApplied`
- `restoredMovies`

Two builder methods now produce that snapshot from the existing restore sources:

- `buildFilterRestoreSnapshotFromSharedPreferences()`
- `buildFilterRestoreSnapshotFromSavedState(...)`

These builders act as strict validation gates and only return a snapshot when restore state is actually valid.

### 2. Centralized Filter restore apply logic
Added:

- `applyFilterSnapshot(...)`

This is now the shared apply path for Filter restore.

Both restore sources route through the same core apply flow:
- enter Filter mode
- restore `movieFilterApplied`
- submit restored movies
- restore Filter UI visibility

The rotation path still supplies its RecyclerView restore work through a callback so the nav-scoped `pendingRvState` behavior remains intact.

### 3. Removed timing-dependent restore behavior
SharedPreferences-based restore is no longer applied before RecyclerView setup.

Instead:
- snapshot is built early
- apply happens only after `setupRecycler()`

This removes the previous timing dependency on adapter / layout manager initialization.

### 4. Removed legacy fallback re-apply logic
Deleted the old `onCreate()` fallback that would re-run `viewModel.applyMovieFilter(...)` when entering Filter with no adapter data.

That logic was part of the previous restore handshake and could compete with the restored snapshot path.

### 5. Deduplicated filtered paging results in `MovieRepository`
Added a filtered-mode dedupe set:

- `filteredSeenMovieIds`

This is:
- cleared when filtered paging starts fresh
- cleared when browse results are cleared
- used to deduplicate `MOVIES_FILTERED` results by movie ID before publishing

This fixes duplicate entries appearing while scrolling filtered results.

## Why

The previous Filter restore flow was fragile because it was spread across:
- `savedInstanceState`
- SharedPreferences
- ViewModel restore calls
- adapter restore calls
- RecyclerView restore calls
- multiple guard flags

That made restore correctness depend heavily on sequencing and callback timing.

This change makes the restore contract more explicit:
- validate restore state once
- represent it as one snapshot
- apply it through one shared path

At the same time, it preserves the rotation-specific RecyclerView restore behavior that still needs nav-aware post-submit handling.

## Behavior preserved

This PR preserves existing user-visible behavior while making restore more deterministic.

Verified flows:
- normal Filter apply still works
- filtered paging still works
- rotation on a filtered list restores Filter + list correctly
- SharedPreferences/external-return restore still restores Filter correctly
- duplicate filtered items no longer appear while paging

## Notes

This PR intentionally keeps rotation-specific RecyclerView state restore in the saved-state callback rather than forcing that behavior into the snapshot itself.

The snapshot currently represents the validated Filter restore contract, while RecyclerView layout restoration remains a rotation-specific post-apply concern.