### PR TITLE
refactor(trailer): move trailer fetch flow to MVVM boundary

### DIFF
--- a/app/src/main/java/com/geoffreysisco/filmatlas/repository/MovieRepository.java
+++ b/app/src/main/java/com/geoffreysisco/filmatlas/repository/MovieRepository.java
@@ -3,13 +3,16 @@ package com.geoffreysisco.filmatlas.repository;
 import android.app.Application;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
 
 import com.geoffreysisco.filmatlas.BuildConfig;
 import com.geoffreysisco.filmatlas.model.MovieFilterOptions;
 import com.geoffreysisco.filmatlas.model.Movie;
+import com.geoffreysisco.filmatlas.model.Trailer;
 import com.geoffreysisco.filmatlas.network.MoviesResponse;
+import com.geoffreysisco.filmatlas.network.TrailerResponse;
 import com.geoffreysisco.filmatlas.serviceapi.MovieApiService;
 import com.geoffreysisco.filmatlas.serviceapi.RetrofitInstance;
 
@@ -75,6 +78,12 @@ public class MovieRepository {
     // Callbacks
     public interface LoadingCallback {
         void onDone();
+    }
+
+    public interface TrailerFetchCallback {
+        void onTrailerKeyReady(@NonNull String youtubeKey);
+        void onNoTrailerFound();
+        void onFetchFailed();
     }
 
     // Constructor
@@ -405,6 +414,46 @@ public class MovieRepository {
         });
     }
 
+    public void fetchBestTrailerKey(int movieId, @NonNull TrailerFetchCallback cb) {
+        if (movieId <= 0) {
+            cb.onFetchFailed();
+            return;
+        }
+
+        MovieApiService api = RetrofitInstance.getService();
+        String apiKey = BuildConfig.TMDB_API_KEY;
+
+        api.getMovieVideos(movieId, apiKey).enqueue(new Callback<TrailerResponse>() {
+            @Override
+            public void onResponse(
+                    @NonNull Call<TrailerResponse> call,
+                    @NonNull Response<TrailerResponse> response
+            ) {
+                TrailerResponse body = response.body();
+                if (!response.isSuccessful() || body == null || body.getResults() == null) {
+                    cb.onNoTrailerFound();
+                    return;
+                }
+
+                String key = pickBestYouTubeKey(body);
+                if (key == null) {
+                    cb.onNoTrailerFound();
+                    return;
+                }
+
+                cb.onTrailerKeyReady(key);
+            }
+
+            @Override
+            public void onFailure(
+                    @NonNull Call<TrailerResponse> call,
+                    @NonNull Throwable t
+            ) {
+                cb.onFetchFailed();
+            }
+        });
+    }
+
     private void loadFirstPageBrowseInternal(@NonNull LoadingCallback cb) {
         browseMovies.clear();
         discoverEmptySkips = 0;
@@ -495,6 +544,24 @@ public class MovieRepository {
             }
         }
         return out;
+    }
+
+    @Nullable
+    private String pickBestYouTubeKey(@NonNull TrailerResponse body) {
+        for (Trailer t : body.getResults()) {
+            if ("YouTube".equalsIgnoreCase(t.getSite())
+                    && "Trailer".equalsIgnoreCase(t.getType())) {
+                return t.getKey();
+            }
+        }
+
+        for (Trailer t : body.getResults()) {
+            if ("YouTube".equalsIgnoreCase(t.getSite())) {
+                return t.getKey();
+            }
+        }
+
+        return null;
     }
 
     public void clearBrowseResults() {

--- a/app/src/main/java/com/geoffreysisco/filmatlas/view/MovieDetailsDialogFragment.java
+++ b/app/src/main/java/com/geoffreysisco/filmatlas/view/MovieDetailsDialogFragment.java
@@ -33,13 +33,8 @@ import androidx.lifecycle.ViewModelProvider;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.request.target.CustomTarget;
 import com.bumptech.glide.request.transition.Transition;
-import com.geoffreysisco.filmatlas.BuildConfig;
 import com.geoffreysisco.filmatlas.R;
 import com.geoffreysisco.filmatlas.model.MovieActionPayload;
-import com.geoffreysisco.filmatlas.model.Trailer;
-import com.geoffreysisco.filmatlas.network.TrailerResponse;
-import com.geoffreysisco.filmatlas.serviceapi.MovieApiService;
-import com.geoffreysisco.filmatlas.serviceapi.RetrofitInstance;
 import com.geoffreysisco.filmatlas.viewmodel.MainActivityViewModel;
 import com.google.android.material.button.MaterialButton;
 import com.google.android.material.color.MaterialColors;
@@ -47,9 +42,6 @@ import com.google.android.material.color.MaterialColors;
 import java.util.Locale;
 
 import jp.wasabeef.glide.transformations.BlurTransformation;
-import retrofit2.Call;
-import retrofit2.Callback;
-import retrofit2.Response;
 
 /**
  * DialogFragment for movie details with artwork, overview, and TMDB/trailer actions.
@@ -140,13 +132,16 @@ public class MovieDetailsDialogFragment extends DialogFragment {
 
         MovieActionPayload payload = readPayload();
 
+        MainActivityViewModel viewModel =
+                new ViewModelProvider(requireActivity()).get(MainActivityViewModel.class);
+
         titleTv.setText(formatTitleWithYear(payload.getTitle(), payload.getReleaseYear()));
         ratingBtn.setText(String.format(Locale.US, "%.2f", payload.getRating()));
         overviewTv.setText(payload.getOverview());
 
         closeBtn.setOnClickListener(v -> dismissAllowingStateLoss());
         ratingBtn.setOnClickListener(v -> openTmdbMoviePage(payload.getMovieId()));
-        trailerBtn.setOnClickListener(v -> fetchAndOpenTrailer(payload.getMovieId(), trailerBtn));
+        trailerBtn.setOnClickListener(v -> viewModel.requestTrailer(payload.getMovieId()));
         whereToWatchBtn.setOnClickListener(v -> openTmdbWatchPage(payload.getMovieId()));
 
         if (shareBtn != null) {
@@ -195,14 +190,41 @@ public class MovieDetailsDialogFragment extends DialogFragment {
             );
         }
 
-        MainActivityViewModel viewModel =
-                new ViewModelProvider(requireActivity()).get(MainActivityViewModel.class);
-
         if (favoriteBtn != null && payload.getMovieId() > 0) {
             viewModel.isFavoriteLive(payload.getMovieId()).observe(this, isFav -> {
                 favoriteBtn.setSelected(Boolean.TRUE.equals(isFav));
             });
         }
+
+        viewModel.getTrailerLoadingLiveData().observe(this, isLoading -> {
+            setTrailerLoading(trailerBtn, Boolean.TRUE.equals(isLoading));
+        });
+
+        viewModel.getTrailerEventLiveData().observe(this, event -> {
+            if (event == null) return;
+
+            switch (event.type) {
+                case OPEN_TRAILER:
+                    if (event.youtubeKey != null) {
+                        openTrailer(event.youtubeKey);
+                    }
+                    break;
+
+                case TRAILER_UNAVAILABLE:
+                    Toast.makeText(requireContext(), R.string.error_trailer_unavailable, Toast.LENGTH_SHORT).show();
+                    break;
+
+                case NETWORK_ERROR:
+                    Toast.makeText(requireContext(), R.string.error_network, Toast.LENGTH_SHORT).show();
+                    break;
+
+                case INVALID_MOVIE_ID:
+                    Toast.makeText(requireContext(), R.string.error_missing_movie_id, Toast.LENGTH_SHORT).show();
+                    break;
+            }
+
+            viewModel.clearTrailerEvent();
+        });
 
         return new AlertDialog.Builder(requireContext())
                 .setView(view)
@@ -338,48 +360,6 @@ public class MovieDetailsDialogFragment extends DialogFragment {
         return Math.max(min, Math.min(max, v));
     }
 
-    private void fetchAndOpenTrailer(int movieId, @NonNull MaterialButton trailerBtn) {
-        if (movieId <= 0) {
-            Toast.makeText(requireContext(), R.string.error_missing_movie_id, Toast.LENGTH_SHORT).show();
-            return;
-        }
-
-        setTrailerLoading(trailerBtn, true);
-
-        MovieApiService api = RetrofitInstance.getService();
-        String apiKey = BuildConfig.TMDB_API_KEY;
-
-        api.getMovieVideos(movieId, apiKey).enqueue(new Callback<TrailerResponse>() {
-            @Override
-            public void onResponse(
-                    @NonNull Call<TrailerResponse> call,
-                    @NonNull Response<TrailerResponse> response
-            ) {
-                setTrailerLoading(trailerBtn, false);
-
-                TrailerResponse body = response.body();
-                if (!response.isSuccessful() || body == null || body.getResults() == null) {
-                    Toast.makeText(requireContext(), R.string.error_trailer_unavailable, Toast.LENGTH_SHORT).show();
-                    return;
-                }
-
-                String key = pickBestYouTubeKey(body);
-                if (key == null) {
-                    Toast.makeText(requireContext(), R.string.error_trailer_unavailable, Toast.LENGTH_SHORT).show();
-                    return;
-                }
-
-                openTrailer(key);
-            }
-
-            @Override
-            public void onFailure(@NonNull Call<TrailerResponse> call, @NonNull Throwable t) {
-                setTrailerLoading(trailerBtn, false);
-                Toast.makeText(requireContext(), R.string.error_network, Toast.LENGTH_SHORT).show();
-            }
-        });
-    }
-
     private void setTrailerLoading(@NonNull MaterialButton trailerBtn, boolean loading) {
         trailerBtn.setEnabled(!loading);
         trailerBtn.setAlpha(loading ? 0.6f : 1f);
@@ -456,24 +436,6 @@ public class MovieDetailsDialogFragment extends DialogFragment {
         } catch (ActivityNotFoundException e) {
             context.startActivity(webIntent);
         }
-    }
-
-    @Nullable
-    private String pickBestYouTubeKey(@NonNull TrailerResponse body) {
-        for (Trailer t : body.getResults()) {
-            if ("YouTube".equalsIgnoreCase(t.getSite())
-                    && "Trailer".equalsIgnoreCase(t.getType())) {
-                return t.getKey();
-            }
-        }
-
-        for (Trailer t : body.getResults()) {
-            if ("YouTube".equalsIgnoreCase(t.getSite())) {
-                return t.getKey();
-            }
-        }
-
-        return null;
     }
 
     private int dpToPx(@NonNull View v, int dp) {

--- a/app/src/main/java/com/geoffreysisco/filmatlas/viewmodel/MainActivityViewModel.java
+++ b/app/src/main/java/com/geoffreysisco/filmatlas/viewmodel/MainActivityViewModel.java
@@ -3,6 +3,7 @@ package com.geoffreysisco.filmatlas.viewmodel;
 import android.app.Application;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.lifecycle.AndroidViewModel;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MediatorLiveData;
@@ -47,6 +48,23 @@ public class MainActivityViewModel extends AndroidViewModel {
         FILTER
     }
 
+    public enum TrailerEventType {
+        OPEN_TRAILER,
+        TRAILER_UNAVAILABLE,
+        NETWORK_ERROR,
+        INVALID_MOVIE_ID
+    }
+
+    public static final class TrailerEvent {
+        @NonNull public final TrailerEventType type;
+        @Nullable public final String youtubeKey;
+
+        public TrailerEvent(@NonNull TrailerEventType type, @Nullable String youtubeKey) {
+            this.type = type;
+            this.youtubeKey = youtubeKey;
+        }
+    }
+
     private final MutableLiveData<DisplayMode> displayMode =
             new MutableLiveData<>(DisplayMode.BROWSE);
 
@@ -68,6 +86,9 @@ public class MainActivityViewModel extends AndroidViewModel {
 
     // Loading: mirrors MovieRepository when not searching; mirrors SearchRepository when searching
     private final MutableLiveData<Boolean> loadingLiveData = new MutableLiveData<>(false);
+
+    private final MutableLiveData<Boolean> trailerLoadingLiveData = new MutableLiveData<>(false);
+    private final MutableLiveData<TrailerEvent> trailerEventLiveData = new MutableLiveData<>(null);
 
     // Search mode flag (Activity depends on this existing)
     private final MutableLiveData<Boolean> searchMode = new MutableLiveData<>(false);
@@ -195,6 +216,55 @@ public class MainActivityViewModel extends AndroidViewModel {
 
     public LiveData<Boolean> getLoadingLiveData() {
         return loadingLiveData;
+    }
+
+    public LiveData<Boolean> getTrailerLoadingLiveData() {
+        return trailerLoadingLiveData;
+    }
+
+    public LiveData<TrailerEvent> getTrailerEventLiveData() {
+        return trailerEventLiveData;
+    }
+
+    public void clearTrailerEvent() {
+        trailerEventLiveData.setValue(null);
+    }
+
+    public void requestTrailer(int movieId) {
+        if (movieId <= 0) {
+            trailerEventLiveData.setValue(
+                    new TrailerEvent(TrailerEventType.INVALID_MOVIE_ID, null)
+            );
+            return;
+        }
+
+        trailerLoadingLiveData.setValue(true);
+
+        movieRepository.fetchBestTrailerKey(movieId, new MovieRepository.TrailerFetchCallback() {
+            @Override
+            public void onTrailerKeyReady(@NonNull String youtubeKey) {
+                trailerLoadingLiveData.postValue(false);
+                trailerEventLiveData.postValue(
+                        new TrailerEvent(TrailerEventType.OPEN_TRAILER, youtubeKey)
+                );
+            }
+
+            @Override
+            public void onNoTrailerFound() {
+                trailerLoadingLiveData.postValue(false);
+                trailerEventLiveData.postValue(
+                        new TrailerEvent(TrailerEventType.TRAILER_UNAVAILABLE, null)
+                );
+            }
+
+            @Override
+            public void onFetchFailed() {
+                trailerLoadingLiveData.postValue(false);
+                trailerEventLiveData.postValue(
+                        new TrailerEvent(TrailerEventType.NETWORK_ERROR, null)
+                );
+            }
+        });
     }
 
     public LiveData<Boolean> isSearchMode() {


### PR DESCRIPTION
## Summary

This PR refactors the trailer fetch flow in `MovieDetailsDialogFragment` so trailer networking and response handling live at the MVVM-correct boundary instead of inside the Fragment.

It moves trailer fetch, TMDB API key usage, response validation, and best YouTube trailer selection into `MovieRepository`, and routes UI-facing trailer behavior through `MainActivityViewModel`.

## What changed

### 1. Moved trailer fetch responsibility into `MovieRepository`
Added a narrow trailer fetch path in `MovieRepository` that now owns:

- TMDB trailer API access
- `TMDB_API_KEY` usage
- response validation
- best YouTube trailer key selection

This removes direct networking and API-key access from the Fragment.

### 2. Added trailer loading + event handling in `MainActivityViewModel`
Added ViewModel-owned trailer flow state:

- trailer loading `LiveData`
- trailer one-shot event `LiveData`
- trailer request entry point
- trailer event clear/reset method

The ViewModel now translates repository outcomes into UI-facing signals:
- open trailer
- trailer unavailable
- network error
- invalid movie ID

### 3. Rewired `MovieDetailsDialogFragment` to observe instead of fetch
Updated the Fragment so it now:

- sends trailer requests through `viewModel.requestTrailer(...)`
- observes trailer loading state to update button UI
- observes trailer events to:
  - launch `openTrailer(...)`
  - show the existing toasts

The Fragment no longer performs:
- Retrofit calls
- API key access
- trailer response parsing
- trailer key selection

### 4. Removed old Fragment-only trailer logic
Deleted the old Fragment-local trailer fetch and parsing code after the new repository/ViewModel path was fully wired and verified.

## Why

Previously, `MovieDetailsDialogFragment` mixed UI responsibilities with data responsibilities by handling:

- trailer networking
- TMDB API key access
- response validation
- trailer selection

That made the trailer flow violate MVVM boundaries.

This change keeps the existing UI behavior but moves each responsibility to the correct layer:
- Repository = data fetch + selection
- ViewModel = state + event coordination
- Fragment = UI + intent launch

## Behavior preserved

The PR preserves the existing trailer-button UX:

- trailer button still shows loading state
- trailer still opens through `openTrailer(...)`
- trailer unavailable still surfaces as a toast
- network failure still surfaces as a toast
- invalid movie ID still surfaces as a toast
- dialog UI and behavior remain unchanged

## Notes

This is a narrow refactor focused only on the trailer flow.

It does not introduce:
- new architecture layers
- dependency injection
- unrelated Fragment cleanup
- UI redesign