### PR TITLE
refactor(genres): repository owns TMDB API key (remove ViewModel dependency)

### DIFF
--- a/app/src/main/java/com/geoffreysisco/filmatlas/repository/GenresRepository.java
+++ b/app/src/main/java/com/geoffreysisco/filmatlas/repository/GenresRepository.java
@@ -1,5 +1,6 @@
 package com.geoffreysisco.filmatlas.repository;
 
+import com.geoffreysisco.filmatlas.BuildConfig;
 import com.geoffreysisco.filmatlas.model.AppDatabase;
 import com.geoffreysisco.filmatlas.model.GenreCacheEntity;
 import com.geoffreysisco.filmatlas.network.GenreDto;
@@ -27,8 +28,8 @@ public class GenresRepository {
         this.api = RetrofitInstance.getService();
     }
 
-    public void refreshGenres(String apiKey) {
-        api.getMovieGenres(apiKey).enqueue(new Callback<GenresResponse>() {
+    public void refreshGenres() {
+        api.getMovieGenres(BuildConfig.TMDB_API_KEY).enqueue(new Callback<GenresResponse>() {
             @Override
             public void onResponse(Call<GenresResponse> call, Response<GenresResponse> response) {
                 GenresResponse body = response.body();

--- a/app/src/main/java/com/geoffreysisco/filmatlas/viewmodel/MainActivityViewModel.java
+++ b/app/src/main/java/com/geoffreysisco/filmatlas/viewmodel/MainActivityViewModel.java
@@ -10,7 +10,6 @@ import androidx.lifecycle.MediatorLiveData;
 import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.Observer;
 
-import com.geoffreysisco.filmatlas.BuildConfig;
 import com.geoffreysisco.filmatlas.model.AppDatabase;
 import com.geoffreysisco.filmatlas.model.GenreCacheEntity;
 import com.geoffreysisco.filmatlas.model.Movie;
@@ -195,7 +194,7 @@ public class MainActivityViewModel extends AndroidViewModel {
         genresLiveData = db.genreDao().observeAll();
 
         genresRepository = new GenresRepository(db);
-        genresRepository.refreshGenres(BuildConfig.TMDB_API_KEY);
+        genresRepository.refreshGenres();
     }
 
     @Override


### PR DESCRIPTION
Moves TMDB API key ownership from MainActivityViewModel into GenresRepository.

Changes:
- GenresRepository.refreshGenres() no longer takes apiKey parameter
- Repository now uses BuildConfig.TMDB_API_KEY internally
- ViewModel calls refreshGenres() with no arguments

Why:
- Removes config/infra concern from ViewModel
- Tightens MVVM boundary (ViewModel → orchestration only)

Behavior:
- No functional changes