### PR TITLE
refactor(genres): enforce MVVM boundary by moving genres flow into repository

### DIFF
--- a/app/src/main/java/com/geoffreysisco/filmatlas/model/Genre.java
+++ b/app/src/main/java/com/geoffreysisco/filmatlas/model/Genre.java
@@ -1,0 +1,16 @@
+package com.geoffreysisco.filmatlas.model;
+
+import androidx.annotation.NonNull;
+
+public class Genre {
+
+    public final int id;
+
+    @NonNull
+    public final String name;
+
+    public Genre(int id, @NonNull String name) {
+        this.id = id;
+        this.name = name;
+    }
+}

--- a/app/src/main/java/com/geoffreysisco/filmatlas/repository/GenresRepository.java
+++ b/app/src/main/java/com/geoffreysisco/filmatlas/repository/GenresRepository.java
@@ -1,7 +1,12 @@
 package com.geoffreysisco.filmatlas.repository;
 
+import android.app.Application;
+
+import androidx.lifecycle.LiveData;
+
 import com.geoffreysisco.filmatlas.BuildConfig;
 import com.geoffreysisco.filmatlas.model.AppDatabase;
+import com.geoffreysisco.filmatlas.model.Genre;
 import com.geoffreysisco.filmatlas.model.GenreCacheEntity;
 import com.geoffreysisco.filmatlas.network.GenreDto;
 import com.geoffreysisco.filmatlas.network.GenresResponse;
@@ -23,9 +28,30 @@ public class GenresRepository {
     private final MovieApiService api;
     private final Executor dbExecutor = Executors.newSingleThreadExecutor();
 
-    public GenresRepository(AppDatabase db) {
-        this.db = db;
+    public GenresRepository(Application application) {
+        this.db = AppDatabase.getInstance(application);
         this.api = RetrofitInstance.getService();
+    }
+
+    public LiveData<List<Genre>> observeGenres() {
+        androidx.lifecycle.MediatorLiveData<List<Genre>> result =
+                new androidx.lifecycle.MediatorLiveData<>();
+
+        result.addSource(db.genreDao().observeAll(), entities -> {
+            if (entities == null) {
+                result.setValue(null);
+                return;
+            }
+
+            List<Genre> mapped = new ArrayList<>(entities.size());
+            for (GenreCacheEntity e : entities) {
+                mapped.add(new Genre(e.id, e.name));
+            }
+
+            result.setValue(mapped);
+        });
+
+        return result;
     }
 
     public void refreshGenres() {

--- a/app/src/main/java/com/geoffreysisco/filmatlas/view/MovieFilterBottomSheet.java
+++ b/app/src/main/java/com/geoffreysisco/filmatlas/view/MovieFilterBottomSheet.java
@@ -13,7 +13,7 @@ import androidx.annotation.Nullable;
 import androidx.lifecycle.ViewModelProvider;
 
 import com.geoffreysisco.filmatlas.R;
-import com.geoffreysisco.filmatlas.model.GenreCacheEntity;
+import com.geoffreysisco.filmatlas.model.Genre;
 import com.geoffreysisco.filmatlas.model.MovieFilterOptions;
 import com.geoffreysisco.filmatlas.viewmodel.MainActivityViewModel;
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
@@ -47,8 +47,8 @@ public class MovieFilterBottomSheet extends BottomSheetDialogFragment {
     private MainActivityViewModel viewModel;
     private Callback callback;
 
-    // Backed by Room (genres table)
-    private List<GenreCacheEntity> genres = new ArrayList<>();
+    // Genres exposed by ViewModel for filter UI
+    private List<Genre> genres = new ArrayList<>();
     private boolean[] checked = new boolean[0];
 
     // View refs (needed for onSaveInstanceState)
@@ -179,7 +179,7 @@ public class MovieFilterBottomSheet extends BottomSheetDialogFragment {
             updateClearVisibility.run();
         });
 
-        // Observe genres from Room and keep UI in sync (careful with restored edits)
+        // Observe genres from ViewModel and keep UI in sync (careful with restored edits)
         viewModel.getGenresLiveData().observe(getViewLifecycleOwner(), list -> {
             if (list == null) return;
 
@@ -332,7 +332,7 @@ public class MovieFilterBottomSheet extends BottomSheetDialogFragment {
         return sortChanged || genreChanged;
     }
 
-    private String formatSelectedGenres(List<GenreCacheEntity> genres, boolean[] checked) {
+    private String formatSelectedGenres(List<Genre> genres, boolean[] checked) {
         if (genres == null || genres.isEmpty() || checked == null) return "Any";
 
         StringBuilder sb = new StringBuilder();

--- a/app/src/main/java/com/geoffreysisco/filmatlas/viewmodel/MainActivityViewModel.java
+++ b/app/src/main/java/com/geoffreysisco/filmatlas/viewmodel/MainActivityViewModel.java
@@ -10,8 +10,7 @@ import androidx.lifecycle.MediatorLiveData;
 import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.Observer;
 
-import com.geoffreysisco.filmatlas.model.AppDatabase;
-import com.geoffreysisco.filmatlas.model.GenreCacheEntity;
+import com.geoffreysisco.filmatlas.model.Genre;
 import com.geoffreysisco.filmatlas.model.Movie;
 import com.geoffreysisco.filmatlas.model.MovieFilterOptions;
 import com.geoffreysisco.filmatlas.repository.FavoritesRepository;
@@ -28,7 +27,7 @@ import java.util.List;
  * - Browse paging lives in MovieRepository (single stream of "grid results")
  * - Search networking + paging + suggestions live in SearchRepository
  * - ViewModel owns UI policy + routing (DisplayMode, no-flash rules, restore behavior)
- * - Genres are cached in Room (GenreCacheEntity) for MovieFilterBottomSheet
+ * - Genres are cached in Room and exposed to UI as Genre models for MovieFilterBottomSheet
  *
  * IMPORTANT:
  * - MovieFilterOptions is NOT persisted in Room (ever). It is in-memory UI state only.
@@ -106,7 +105,7 @@ public class MainActivityViewModel extends AndroidViewModel {
 
     // Genres cache (Room)
 
-    private final LiveData<List<GenreCacheEntity>> genresLiveData;
+    private final LiveData<List<Genre>> genresLiveData;
 
     // Search state
 
@@ -189,11 +188,9 @@ public class MainActivityViewModel extends AndroidViewModel {
         searchRepoSuggestionsObserver = list -> suggestionsLiveData.postValue(list);
         searchRepository.getSuggestionsLiveData().observeForever(searchRepoSuggestionsObserver);
 
-        // Genres: ViewModel observes Room cache only; GenresRepository handles network refresh
-        AppDatabase db = AppDatabase.getInstance(application);
-        genresLiveData = db.genreDao().observeAll();
-
-        genresRepository = new GenresRepository(db);
+        // Genres: repository owns Room observation + network refresh
+        genresRepository = new GenresRepository(application);
+        genresLiveData = genresRepository.observeGenres();
         genresRepository.refreshGenres();
     }
 
@@ -276,7 +273,7 @@ public class MainActivityViewModel extends AndroidViewModel {
 
     // Genres (Room cache)
 
-    public LiveData<List<GenreCacheEntity>> getGenresLiveData() {
+    public LiveData<List<Genre>> getGenresLiveData() {
         return genresLiveData;
     }
 


### PR DESCRIPTION
## Summary
Enforces MVVM boundaries for the genres feature by moving all data ownership into `GenresRepository` and decoupling the UI/ViewModel from Room.

## Changes
- Introduced `Genre` domain model for UI consumption
- Moved Room observation into `GenresRepository` (`observeGenres()`)
- Mapped `GenreCacheEntity -> Genre` inside repository
- Removed direct DAO / `AppDatabase` usage from `MainActivityViewModel`
- Updated `MovieFilterBottomSheet` to use `Genre` instead of persistence model

## Result
- Repository is now the single source of truth for genres (network + DB)
- ViewModel no longer depends on Room
- UI no longer depends on Room entities
- Aligns genres flow with existing repository-driven patterns (favorites, search)

## Scope
- Limited to genres flow only
- No DI, networking, or pagination changes

## Notes
This is a boundary cleanup refactor. No functional behavior changes expected.