### PR TITLE
fix(filter): empty-state incorrectly showing "No matches found" after rotation

### DIFF
--- a/app/src/main/java/com/geoffreysisco/filmatlas/MainActivity.java
+++ b/app/src/main/java/com/geoffreysisco/filmatlas/MainActivity.java
@@ -1737,8 +1737,9 @@ public class MainActivity extends AppCompatActivity
         if (binding.recyclerView.getVisibility() == View.VISIBLE
                 && movieAdapter != null
                 && movieAdapter.getItemCount() == 0) {
-
-            binding.contentContainer.post(() -> showFilterEmptyState(true));
+            binding.contentContainer.post(() ->
+                    showFilterEmptyState(viewModel.isMovieFilterApplied())
+            );
         }
 
         applyMainTabTitles();


### PR DESCRIPTION
## Summary
Fixes incorrect Filter empty-state after rotation when no filter is applied.

## Problem
Rotating in Movie Filter with no active filter incorrectly showed "No matches found" instead of "No filter applied".

Root cause:
A fallback in `enterFilterMode(...)` assumed that:
- visible RecyclerView + empty adapter == filter applied with no results

This bypassed the real state (`viewModel.isMovieFilterApplied()`), causing rotation to force the wrong empty state.

## Fix
Replace hardcoded:
    showFilterEmptyState(true)

With:
    showFilterEmptyState(viewModel.isMovieFilterApplied())

## Result
- "No filter applied" persists correctly across rotation
- "No matches found" still appears only when a filter is actually applied
- No change to normal filter result flows

## Verification
- Case A (no filter): rotation preserves "No filter applied" ✅
- Case B (filter with 0 results): rotation preserves "No matches found" ✅