### PR TITLE
fix(search): results disappear after rotation restore

### DIFF
--- a/app/src/main/java/com/geoffreysisco/filmatlas/MainActivity.java
+++ b/app/src/main/java/com/geoffreysisco/filmatlas/MainActivity.java
@@ -304,10 +304,12 @@ public class MainActivity extends AppCompatActivity
                     viewModel.restoreSearchUiStateOnly();
                 }
 
-                if (selectedNavIndex == NAV_FAVORITES) {
-                    enterFavoritesMode();
-                } else if (selectedNavIndex == NAV_FILTER) {
-                    enterFilterMode(false, false);
+                if (!wasInSearch) {
+                    if (selectedNavIndex == NAV_FAVORITES) {
+                        enterFavoritesMode();
+                    } else if (selectedNavIndex == NAV_FILTER) {
+                        enterFilterMode(false, false);
+                    }
                 }
 
                 if (input != null) {

--- a/app/src/main/java/com/geoffreysisco/filmatlas/viewmodel/MainActivityViewModel.java
+++ b/app/src/main/java/com/geoffreysisco/filmatlas/viewmodel/MainActivityViewModel.java
@@ -315,7 +315,6 @@ public class MainActivityViewModel extends AndroidViewModel {
     public void restoreSearchUiStateOnly() {
         searchMode.setValue(true);
         displayMode.setValue(DisplayMode.SEARCH);
-        searchCoordinator.clearSearchResultsOnly();
     }
 
     // Suggestions


### PR DESCRIPTION
## Summary
Fixes committed search results disappearing after rotation.

## Problem
Rotating after a committed search cleared the RecyclerView.

Root cause:
`restoreSearchUiStateOnly()` restored search mode, but also cleared search results:

- `restoreSearchUiStateOnly()`
- `clearSearchResultsOnly()`
- adapter receives empty list

Additionally, restore could re-enter Filter/Favorites while search was active, allowing non-search UI paths to hide the RecyclerView.

## Fix
Remove result clearing from `restoreSearchUiStateOnly()`.

Also skip Filter/Favorites re-entry during committed search restore.

## Result
- committed search results persist across rotation
- RecyclerView stays populated
- no blank screen on browse tabs
- no Filter empty-state override during active search

## Verification
- Discover → search → rotate ✅
- Popular → search → rotate ✅
- Favorites → search → rotate ✅
- Filter → search → rotate ✅