### PR TITLE
fix(search): restore search return target after rotation

### DIFF
--- a/app/src/main/java/com/geoffreysisco/filmatlas/MainActivity.java
+++ b/app/src/main/java/com/geoffreysisco/filmatlas/MainActivity.java
@@ -301,6 +301,7 @@ public class MainActivity extends AppCompatActivity
                 restoringSearchUi = true;
 
                 if (wasInSearch) {
+                    restoreSearchReturnTargetFromNavIndex(selectedNavIndex);
                     viewModel.restoreSearchUiStateOnly();
                 }
 
@@ -2569,6 +2570,21 @@ public class MainActivity extends AppCompatActivity
         } else if (uiMode == UiMode.FILTER) {
             lastModeTabIndex = MODE_TAB_FILTER;
         }
+    }
+
+    private void restoreSearchReturnTargetFromNavIndex(int navIndex) {
+        if (navIndex == NAV_FAVORITES) {
+            lastModeTabIndex = MODE_TAB_FAVORITES;
+            return;
+        }
+
+        if (navIndex == NAV_FILTER) {
+            lastModeTabIndex = MODE_TAB_FILTER;
+            return;
+        }
+
+        lastModeTabIndex = -1;
+        lastBrowseTabIndex = mapNavIndexToBrowseTab(navIndex);
     }
 
     private void hideSuggestions() {


### PR DESCRIPTION
## Summary
Fixes search return target resetting to Discover after rotation.

## Problem
Rotating during a committed search lost the original tab context.

Root cause:
`lastBrowseTabIndex` and `lastModeTabIndex` reset after Activity recreation.

Search restore preserved search mode, but did not restore the return target used by the Back-to button:

- `selectedNavIndex` restored correctly
- `restoreSearchUiStateOnly()` restored search mode
- `lastBrowseTabIndex` / `lastModeTabIndex` stayed at defaults
- Back-to label/action fell back to Discover

## Fix
Restore the search return target from `selectedNavIndex` during committed search restore.

## Result
- Back-to label stays aligned with the original tab
- exiting search returns to the correct tab
- no fallback to Discover after rotation
- works for Favorites, Filter, and browse tabs

## Verification
- Favorites → search → rotate → clear → Back to Favorites ✅
- Filter → search → rotate → clear → Back to Movie Filter ✅
- Popular → search → rotate → clear → Back to Popular ✅
- New → search → rotate → clear → Back to New ✅
- Discover baseline unchanged ✅