### PR TITLE
fix(search): prevent suggestions from persisting after hardware Enter

### DIFF
--- a/app/src/main/java/com/geoffreysisco/filmatlas/MainActivity.java
+++ b/app/src/main/java/com/geoffreysisco/filmatlas/MainActivity.java
@@ -13,6 +13,7 @@ import android.os.Parcelable;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.view.GestureDetector;
+import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewConfiguration;
@@ -118,6 +119,7 @@ public class MainActivity extends AppCompatActivity
 
     private final Handler searchHandler = new Handler(Looper.getMainLooper());
     private boolean suppressSuggestionFetch = false;
+    private boolean suppressSuggestionsAfterSubmit = false;
     private boolean restoringSearchUi = false;
     private boolean restoringBrowseUi = false;
     private boolean restoredBrowseSnapshot = false;
@@ -887,6 +889,7 @@ public class MainActivity extends AppCompatActivity
                 }
 
                 if (suppressSuggestionFetch) return;
+                suppressSuggestionsAfterSubmit = false;
 
                 if (searchSuggestionsRunnable != null) {
                     searchHandler.removeCallbacks(searchSuggestionsRunnable);
@@ -931,7 +934,14 @@ public class MainActivity extends AppCompatActivity
         }
 
         input.setOnEditorActionListener((v, actionId, event) -> {
-            if (actionId != EditorInfo.IME_ACTION_SEARCH) return false;
+            boolean isImeSearch = actionId == EditorInfo.IME_ACTION_SEARCH;
+
+            boolean isEnterKey =
+                    event != null
+                            && event.getKeyCode() == KeyEvent.KEYCODE_ENTER
+                            && event.getAction() == KeyEvent.ACTION_DOWN;
+
+            if (!isImeSearch && !isEnterKey) return false;
 
             if (!isInSearchMode()) {
                 rememberLastPlaceBeforeSearch();
@@ -945,6 +955,7 @@ public class MainActivity extends AppCompatActivity
                 searchSuggestionsRunnable = null;
             }
 
+            suppressSuggestionsAfterSubmit = true;
             hideSuggestions();
 
             hideKeyboard(v);
@@ -1054,6 +1065,7 @@ public class MainActivity extends AppCompatActivity
             }
 
             String text = (input.getText() == null) ? "" : input.getText().toString().trim();
+            suppressSuggestionsAfterSubmit = false;
             viewModel.fetchSuggestions(text);
             if (suggestionsList != null) suggestionsList.setVisibility(View.VISIBLE);
         });
@@ -1439,7 +1451,11 @@ public class MainActivity extends AppCompatActivity
         viewModel.getSuggestionsLiveData().observe(this, list -> {
 
             boolean shouldShowSuggestions =
-                    list != null && !list.isEmpty() && input != null && input.hasFocus();
+                    !suppressSuggestionsAfterSubmit
+                            && list != null
+                            && !list.isEmpty()
+                            && input != null
+                            && input.hasFocus();
 
             if (shouldShowSuggestions) {
                 suggestionsAdapter.submit(list);

--- a/app/src/main/res/layout-land/activity_main.xml
+++ b/app/src/main/res/layout-land/activity_main.xml
@@ -4,9 +4,19 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/root_layout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         tools:context="com.geoffreysisco.filmatlas.MainActivity">
+
+        <View
+            android:id="@+id/initial_focus_anchor"
+            android:layout_width="1dp"
+            android:layout_height="1dp"
+            android:focusable="true"
+            android:focusableInTouchMode="true"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
 
         <!-- Top app bar -->
         <com.google.android.material.appbar.MaterialToolbar

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -7,9 +7,16 @@
         android:id="@+id/root_layout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:clickable="true"
-        android:focusable="true"
         tools:context="com.geoffreysisco.filmatlas.MainActivity">
+
+        <View
+            android:id="@+id/initial_focus_anchor"
+            android:layout_width="1dp"
+            android:layout_height="1dp"
+            android:focusable="true"
+            android:focusableInTouchMode="true"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
 
         <!-- Top app bar (search pill is a toolbar child for full-width layout) -->
         <com.google.android.material.appbar.MaterialToolbar


### PR DESCRIPTION
## Summary
Fixes search suggestions persisting after hardware Enter and incorrect search focus behavior.

## Problem
Pressing hardware Enter would commit the search, but suggestions would reappear immediately.

Root cause:
Search submit and suggestions display were not fully decoupled.

- `onEditorAction` did not properly handle hardware Enter
- `hideSuggestions()` was called, but observer emissions re-triggered visibility
- suggestions visibility depended only on `input.hasFocus()`
- no mechanism existed to suppress suggestions after submit
- EditText could regain or retain focus, causing inconsistent UI state
- startup focus defaulted to the search pill due to lack of a safe focus target

## Fix
Introduce a controlled suppression flow and proper focus handling:

- handle hardware Enter (`KEYCODE_ENTER`) in `OnEditorActionListener`
- add `suppressSuggestionsAfterSubmit` to block observer-driven re-display
- set suppression on submit, clear it on:
  - text change
  - search pill focus re-entry
- keep suggestions tied to user interaction instead of raw focus
- add an invisible focus anchor to prevent EditText auto-focus on startup
- remove root focus attributes that caused haze
- normalize root layout IDs across orientations

## Result
- hardware Enter commits search without suggestions reappearing
- suggestions hide reliably after submit
- tapping back into search restores suggestions correctly
- no flashing/disappearing suggestions
- search pill does not auto-focus on startup
- no haze or unintended dimming
- consistent behavior in portrait and landscape

## Verification
- type query → Enter → suggestions hidden, results shown ✅
- hardware Enter behaves same as IME search action ✅
- tap search pill after submit → suggestions show again ✅
- edit query after submit → suggestions update normally ✅
- fresh launch → no focus, no suggestions visible ✅
- portrait and landscape behavior consistent ✅